### PR TITLE
Remove demo announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,14 +136,6 @@ const config = {
           hideable: true,
         },
       },
-      announcementBar: {
-        id: "feedback_form",
-        content:
-          'This is a demonstration that we can put a pop-up message here! Even <a target="_blank" rel="noopener noreferrer" href="#">links</a>',
-        backgroundColor: "#fafbfc",
-        textColor: "#091E42",
-        isCloseable: true,
-      },
       navbar: {
         title: `${title}`,
         logo: {


### PR DESCRIPTION
Removes the demo announcement bar:

<img width="715" alt="Screenshot 2025-02-20 at 16 13 19" src="https://github.com/user-attachments/assets/f97e672d-089f-4cfe-bf36-42b0d5a96251" />
