### PR TITLE
Fixed all code samples to use genres instead of genre.

### DIFF
--- a/docs/40-CRUD/1-WHERE.mdx
+++ b/docs/40-CRUD/1-WHERE.mdx
@@ -151,7 +151,7 @@ Now, translate the following into a MongoDB query.
     <TabItem value="javascript" label="JavaScript">
       <div>
         ```js
-        const cursor = await books.find( { "genre.name": "Science", pages: {$gt: 300} } );
+        const cursor = await books.find( { "genres": "Science", pages: {$gt: 300} } );
 
         await cursor.forEach((b) => {
             console.log(b);
@@ -162,7 +162,7 @@ Now, translate the following into a MongoDB query.
     <TabItem value="mongosh" label="mongosh">
         <div>
           ```js
-          db.books.find({ "genre.name": "Science", pages: {$gt: 300} });
+          db.books.find({ "genres": "Science", pages: {$gt: 300} });
           ```
         </div>
     </TabItem>

--- a/docs/40-CRUD/2-SELECT.mdx
+++ b/docs/40-CRUD/2-SELECT.mdx
@@ -58,7 +58,7 @@ Here:
 ## **Example 3: Using projection along with a query**
 
 ```js
-db.books.find({ "genre.name": "Science" }, { title: 1, totalInventory: 1, _id: 0 });
+db.books.find({ "genres": "Science" }, { title: 1, totalInventory: 1, _id: 0 });
 ```
 
 **Equivalent SQL query:**
@@ -111,7 +111,7 @@ Here:
     <TabItem value="javascript" label="JavaScript">
       <div>
           ```js
-          const cursor = await books.find({ "genre.name": "History" }).project( { _id: 0, authors: 0 } ).limit(10);
+          const cursor = await books.find({ "genres": "History" }).project( { _id: 0, authors: 0 } ).limit(10);
 
           await cursor.forEach((b) => {
               console.log(b);
@@ -122,7 +122,7 @@ Here:
     <TabItem value="mongosh" label="mongosh">
         <div>
           ```js
-          db.books.find({ "genre.name": "History" }, { _id: 0, authors: 0 });
+          db.books.find({ "genres": "History" }, { _id: 0, authors: 0 });
           ```
         </div>
     </TabItem>

--- a/docs/40-CRUD/3-ORDER-LIMIT.mdx
+++ b/docs/40-CRUD/3-ORDER-LIMIT.mdx
@@ -40,7 +40,7 @@ This fetches the **5 books with the highest stock**.
 
 ```js
 db.books
-  .find({ "genre.name": "Fiction" }, { title: 1, pages: 1 })
+  .find({ "genres": "Fiction" }, { title: 1, pages: 1 })
   .sort({ pages: -1 })
   .limit(10);
 ```

--- a/docs/50-aggregation/7-merge.mdx
+++ b/docs/50-aggregation/7-merge.mdx
@@ -47,12 +47,12 @@ The `$merge` stage enables you to store aggregation results into a different col
 
 ## **🔹 Example 1: Creating a summary collection**
 
-👉 Suppose we want to generate a collection that contains the **total number of books per genre**.
+👉 Suppose we want to generate a collection that contains the **total number of books per genre**. Using mongosh:
 
 ```js
 db.books.aggregate([
-  { $unwind: "$genre" },
-  { $group: { _id: "$genre.genreId", totalBooks: { $sum: 1 } } },
+  { $unwind: "$genres" },
+  { $group: { _id: "$genres", totalBooks: { $sum: 1 } } },
   {
     $merge: {
       into: "genre_summary",


### PR DESCRIPTION
 Genres is an array of strings now (not an array of objects), so no `genre.name` or `genre.id`